### PR TITLE
Ticket#206393-[API] Pouvoir obtenir les typologies actives pour un projet

### DIFF
--- a/lib/helpers/projects_helper_patch.rb
+++ b/lib/helpers/projects_helper_patch.rb
@@ -18,6 +18,7 @@ module PluginTypology
     end
 
     def render_api_includes(project, api)
+      super
       api.array :typologies do
         project.typologies.each do |typology|
           api.typology(:id => typology.id, :name => typology.name)

--- a/lib/helpers/projects_helper_patch.rb
+++ b/lib/helpers/projects_helper_patch.rb
@@ -17,6 +17,14 @@ module PluginTypology
       tabs
     end
 
+    def render_api_includes(project, api)
+      api.array :typologies do
+        project.typologies.each do |typology|
+          api.typology(:id => typology.id, :name => typology.name)
+        end
+      end if include_in_api_response?('typologies')
+      
+    end
   end
 
 end

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -2,6 +2,7 @@ require "spec_helper"
 
 describe ProjectsController, :type => :controller do
   fixtures  :users, :projects, :enumerations
+  render_views
 
   before do
     @request.session[:user_id] = 1
@@ -10,12 +11,14 @@ describe ProjectsController, :type => :controller do
   describe "copy a project" do
     let(:source_project) { Project.find(2) }
 
-    it "Copy all typologies" do
+    before do
       Typology.create(name: "typo1", active: true, is_default: true)
       Typology.create(name: "typo2", active: true)
       ProjectTypology.create(project_id: source_project.id, typology_id: Typology.first.id, active: true, tracker_ids: [1, 2])
       ProjectTypology.create(project_id: source_project.id, typology_id: Typology.last.id, active: false, tracker_ids: [1, 3])
+    end
 
+    it "Copy all typologies" do
       expect do
         post :copy, :params => {
           :id => source_project.id,
@@ -40,5 +43,23 @@ describe ProjectsController, :type => :controller do
       expect(pt2.tracker_ids).to eq([1, 3])
 
     end
+
+    it "should display active typologies in project/show api" do
+      source_project.is_public = true;
+      source_project.save
+
+      typology_first = Typology.first
+      typology_second = Typology.last
+
+      get :show, params: {:id => source_project.identifier, :include => ["typologies"], :format => 'json' }
+      expect(response).to have_http_status(200)
+
+      st_first = "{\"id\":#{typology_first.id},\"name\":\"#{typology_first.name}\"}"
+      expect(response.body).to include(st_first)
+
+      st_second = "{\"id\":#{typology_second.id},\"name\":\"#{typology_second.name}\"}"
+      expect(response.body).not_to include(st_second)
+    end
+
   end
 end


### PR DESCRIPTION
- Surcharger la méthode render_api_includes
- Test